### PR TITLE
refactor(vectorMemoryService): adjust embedding initialization in con…

### DIFF
--- a/src/services/vectorMemoryService.ts
+++ b/src/services/vectorMemoryService.ts
@@ -51,11 +51,11 @@ export class VectorMemoryService {
   private isRedisInitialized: boolean = false;
 
   constructor(questionModel: ChatOpenAI | ChatGroq | ChatGoogleGenerativeAI | HuggingFaceInference) {
-    // this.embeddings = new OpenAIEmbeddings({ 
-    //   apiKey: process.env.OPENAI_API_KEY as string 
-    // });
+    this.embeddings = new OpenAIEmbeddings({ 
+      apiKey: process.env.OPENAI_API_KEY as string 
+    });
 
-    this.embeddings = transformerEmbeddings;
+    // this.embeddings = transformerEmbeddings;
 
     this.supabaseClient = createClient(
       process.env.SUPABASE_URL as string, 


### PR DESCRIPTION
This pull request updates the initialization of the `embeddings` property in the `VectorMemoryService` to use OpenAI embeddings by default, replacing the previous assignment to `transformerEmbeddings`. This change ensures that the service leverages OpenAI's embedding model for vector operations.

Embedding model initialization:

* Changed the default embedding model in the `VectorMemoryService` constructor to use `OpenAIEmbeddings` with the API key from environment variables, commenting out the previous use of `transformerEmbeddings`.…structor